### PR TITLE
BUG-65 fix deprecation warning 

### DIFF
--- a/lib/backgrounder/orm/activemodel.rb
+++ b/lib/backgrounder/orm/activemodel.rb
@@ -19,7 +19,7 @@ module CarrierWave
             options = self.class.uploader_options[column] || {}
             serialization_column = options[:mount_on] || column
 
-            send(:"#{serialization_column}_changed?") ||              # after_save support
+            send(:"saved_change_to_#{serialization_column}?") ||      # after_save support
             previous_changes.has_key?(:"#{serialization_column}") ||  # after_commit support
             send(:"remote_#{column}_url").present? ||                 # Remote upload support
             send(:"#{column}_cache").present?                         # Form failure support

--- a/lib/backgrounder/version.rb
+++ b/lib/backgrounder/version.rb
@@ -1,5 +1,5 @@
 module CarrierWave
   module Backgrounder
-    VERSION = "0.4.2"
+    VERSION = "0.5.0"
   end
 end

--- a/spec/backgrounder/orm/activemodel_spec.rb
+++ b/spec/backgrounder/orm/activemodel_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CarrierWave::Backgrounder::ORM::ActiveModel do
     @mock_class = Class.new do
       def self.before_save(method, opts); nil; end
       def self.after_commit(method, opts); nil; end
-      def avatar_changed?; nil;  end
+      def saved_change_to_avatar?; nil;  end
       def remote_avatar_url; OpenStruct.new(:present? => true); end
       def remove_avatar?; false; end
       def previous_changes; {}; end
@@ -54,7 +54,7 @@ RSpec.describe CarrierWave::Backgrounder::ORM::ActiveModel do
       end
 
       it "returns true if alternate column is changed" do
-        expect(instance).to receive(:some_other_column_changed?).and_return(true)
+        expect(instance).to receive(:saved_change_to_some_other_column?).and_return(true)
         expect(instance.avatar_updated?).to be_truthy
       end
     end
@@ -66,20 +66,20 @@ RSpec.describe CarrierWave::Backgrounder::ORM::ActiveModel do
 
     it "calls column_changed?" do
       expect(instance).to receive(:process_avatar_upload).and_return(false)
-      expect(instance).to receive(:avatar_changed?)
+      expect(instance).to receive(:saved_change_to_avatar?)
       expect(instance.enqueue_avatar_background_job?).to be_truthy
     end
 
     it "calls previous_changes" do
       expect(instance).to receive(:process_avatar_upload).and_return(false)
-      expect(instance).to receive(:avatar_changed?).and_return(false)
+      expect(instance).to receive(:saved_change_to_avatar?).and_return(false)
       expect(instance).to receive(:previous_changes).and_return({:avatar => true})
       expect(instance.enqueue_avatar_background_job?).to be_truthy
     end
 
     it "calls avatar_remote_url" do
       expect(instance).to receive(:process_avatar_upload).and_return(false)
-      expect(instance).to receive(:avatar_changed?).and_return(false)
+      expect(instance).to receive(:saved_change_to_avatar?).and_return(false)
       expect(instance).to receive(:previous_changes).and_return({})
       expect(instance).to receive(:remote_avatar_url).and_return('yup')
       expect(instance.enqueue_avatar_background_job?).to be_truthy
@@ -87,7 +87,7 @@ RSpec.describe CarrierWave::Backgrounder::ORM::ActiveModel do
 
     it "calls avatar_cache" do
       expect(instance).to receive(:process_avatar_upload).and_return(false)
-      expect(instance).to receive(:avatar_changed?).and_return(false)
+      expect(instance).to receive(:saved_change_to_avatar?).and_return(false)
       expect(instance).to receive(:previous_changes).and_return({})
       expect(instance).to receive(:remote_avatar_url).and_return(nil)
       expect(instance).to receive(:avatar_cache).and_return('yup')


### PR DESCRIPTION
Fix 
```
DEPRECATION WARNING: The behavior of `attribute_changed?` inside of after callbacks will be changing in the next version of Rails. The new return value will reflect the behavior of calling the method after `save` returned (e.g. the opposite of what it returns now). To maintain the current behavior, use `saved_change_to_attribute?` instead. (called from block in _define_shared_backgrounder_methods at /Users/aaeabdo/.rvm/gems/ruby-2.4.1/bundler/gems/carrierwave_backgrounder-460394b0e2c0/lib/backgrounder/orm/activemodel.rb:22)
```

https://caspar.atlassian.net/browse/BUG-65