### PR TITLE
fix: serialisation to JSON is unsafe and sidekiq warns about it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
  - 2.0.0
  - 2.1
  - 2.2
- - 2.3
  - ruby-head
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ end
 
 ### Testing with Rspec
 We use the after_commit hook when using active_record. This creates a problem when testing with Rspec because after_commit never gets fired
-if you're using trasactional fixtures. One solution to the problem is to use the [TestAfterCommit gem](https://github.com/grosser/test_after_commit).
+if you're using transactional fixtures. One solution to the problem is to use the [TestAfterCommit gem](https://github.com/grosser/test_after_commit).
 There are various other solutions in which case google is your friend.
 
 ### Uploaders mounted on mongoid embedded documents

--- a/carrierwave_backgrounder.gemspec
+++ b/carrierwave_backgrounder.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "carrierwave", [">= 0.5", "< 2.2"]
-  s.add_dependency "mime-types", ["~> 3.2"]
 
   s.add_development_dependency "rspec", ["~> 3.10.0"]
   s.add_development_dependency "rake"

--- a/carrierwave_backgrounder.gemspec
+++ b/carrierwave_backgrounder.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "carrierwave", [">= 0.5", "< 2.0"]
-  s.add_dependency "mime-types", ["~> 2.99"]
+  s.add_dependency "carrierwave", [">= 0.5", "< 2.2"]
+  s.add_dependency "mime-types", ["~> 3.2"]
 
-  s.add_development_dependency "rspec", ["~> 3.5.0"]
+  s.add_development_dependency "rspec", ["~> 3.10.0"]
   s.add_development_dependency "rake"
 end

--- a/lib/backgrounder/orm/base.rb
+++ b/lib/backgrounder/orm/base.rb
@@ -82,7 +82,7 @@ module CarrierWave
 
             def write_#{column}_identifier
               super and return if process_#{column}_upload
-              self.#{column}_tmp = _mounter(:#{column}).cache_name if _mounter(:#{column}).cache_name
+              self.#{column}_tmp = #{column}_cache if #{column}_cache
             end
 
             def store_#{column}!

--- a/lib/backgrounder/orm/data_mapper.rb
+++ b/lib/backgrounder/orm/data_mapper.rb
@@ -26,7 +26,7 @@ module CarrierWave
 
             def write_#{column}_identifier
               super and return if process_#{column}_upload
-              self.#{column}_tmp = _mounter(:#{column}).cache_name
+              self.#{column}_tmp = #{column}_cache
             end
           RUBY
         end

--- a/lib/backgrounder/support/backends.rb
+++ b/lib/backgrounder/support/backends.rb
@@ -48,7 +48,7 @@ module CarrierWave
 
           def enqueue_sidekiq(worker, *args)
             override_queue_name = worker.sidekiq_options['queue'] == 'default' || worker.sidekiq_options['queue'].nil?
-            args = sidekiq_queue_options(override_queue_name, 'class' => worker, 'args' => args)
+            args = sidekiq_queue_options(override_queue_name, 'class' => worker, 'args' => args.map(&:to_s))
             worker.client_push(args)
           end
 

--- a/spec/backgrounder/support/backends_spec.rb
+++ b/spec/backgrounder/support/backends_spec.rb
@@ -122,7 +122,7 @@ module CarrierWave::Backgrounder
         let(:args) { ['FakeClass', 1, :image] }
 
         it 'invokes client_push on the class with passed args' do
-          expect(MockSidekiqWorker).to receive(:client_push).with({ 'class' => MockSidekiqWorker, 'args' => args })
+          expect(MockSidekiqWorker).to receive(:client_push).with({ 'class' => MockSidekiqWorker, 'args' => args.map(&:to_s) })
           mock_module.backend :sidekiq
           mock_module.enqueue_for_backend(MockSidekiqWorker, *args)
         end
@@ -132,7 +132,7 @@ module CarrierWave::Backgrounder
                                                                     'retry' => false,
                                                                     'timeout' => 60,
                                                                     'queue' => :awesome_queue,
-                                                                    'args' => args })
+                                                                    'args' => args.map(&:to_s) })
           options = {:retry => false, :timeout => 60, :queue => :awesome_queue}
           mock_module.backend :sidekiq, options
           mock_module.enqueue_for_backend(MockSidekiqWorker, *args)
@@ -142,7 +142,7 @@ module CarrierWave::Backgrounder
           expect(MockNamedSidekiqWorker).to receive(:client_push).with({ 'class' => MockNamedSidekiqWorker,
                                                                     'retry' => false,
                                                                     'timeout' => 60,
-                                                                    'args' => args })
+                                                                    'args' => args.map(&:to_s) })
           options = {:retry => false, :timeout => 60}
           mock_module.backend :sidekiq, options
           mock_module.enqueue_for_backend(MockNamedSidekiqWorker, *args)


### PR DESCRIPTION
This PR updates the carrierwave_backgrounder's base job to prevent Sidekiq warnings regarding unsafe argument de-/serialization.

Kudos go to [holstvoogd](https://github.com/holstvoogd) and https://github.com/lardawge/carrierwave_backgrounder/pull/307 🙇🏽🙇🏽🙇🏽

Example warning emitted by latest Sidekiq v6:

```
2023-04-25T15:18:56.935Z pid=40 tid=1byk WARN: Job arguments to CarrierWave::Workers::ProcessAsset do not serialize to JSON safely. This will raise an error in
Sidekiq 7.0. See https://github.com/mperham/sidekiq/wiki/Best-Practices or raise an error today
by calling `Sidekiq.strict_args!` during Sidekiq initialization.
```

These changes open up the path to Sidekiq 7.